### PR TITLE
Remove most inlining and special _irq functions

### DIFF
--- a/fifo.c
+++ b/fifo.c
@@ -14,7 +14,16 @@ void fifo_queue_put(fifo_queue_t *queue, fifo_t *p)
 {
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
     {
-        fifo_queue_put_irq(queue, p);
+        p->next = NULL;
+        if (queue->tail)
+        {
+            queue->tail->next = p;
+            queue->tail = p;
+        }
+        else
+        {
+            queue->head = queue->tail = p;
+        }
     }
 }
 
@@ -24,7 +33,13 @@ fifo_t         *fifo_queue_get(fifo_queue_t *queue)
 
     ATOMIC_BLOCK(ATOMIC_RESTORESTATE)
     {
-        p = fifo_queue_get_irq(queue);
+        p = queue->head;
+        if (p)
+        {
+            queue->head = p->next;
+            if (!(queue->head))
+                queue->tail = NULL;
+        }
     }
 
     return p;

--- a/fifo.h
+++ b/fifo.h
@@ -32,49 +32,6 @@ typedef struct
 
 
 /**
- * Inline version of fifo_queue_put for use in interrupts.
- *
- * @param queue Pointer to queue handle.
- * @param p     Pointer to fifo data element.
- */
-__attribute__((always_inline))
-static inline void fifo_queue_put_irq(fifo_queue_t *queue, fifo_t *p)
-{
-    p->next = NULL;
-    if (queue->tail)
-    {
-        queue->tail->next = p;
-        queue->tail = p;
-    }
-    else
-    {
-        queue->head = queue->tail = p;
-    }
-}
-
-/**
- * Inline version of fifo_queue_get for use in interrupts.
- *
- * @param queue Pointer to queue handle.
- * @return      Pointer to fifo data element, or NULL if queue is empty.
- */
-__attribute__((always_inline))
-static inline fifo_t *fifo_queue_get_irq(fifo_queue_t *queue)
-{
-    fifo_t         *p;
-
-    p = queue->head;
-    if (p)
-    {
-        queue->head = p->next;
-        if (!(queue->head))
-            queue->tail = NULL;
-    }
-
-    return p;
-}
-
-/**
  * Put an item on a queue.
  *
  * @param queue Pointer to queue handle.


### PR DESCRIPTION
By using attribute flatten on more interrupts, many inline and
duplicated _irq functions can be removed with very little overhead to
the interrupts.
Ideally ISR_FLATTEN should be used, but Microchip Studio uses an older
gcc compiler, that doesn't support this attribute.