### PR TITLE
Make XDIR pin configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ LNMONITOR | Write all received LocoNet data on debug shell
 LNECHO | Receive and process the echo of data sent from the library itself
 LNPACKET_SIZE_MAX | Use small LN packets to conserve memory. Full packet size is used if not set
 LNPACKET_CNT | Number of LN packets in RAM. Defaults to 8 if not set
+XDIR_PORT and XDIR_PORT_ID | Port to use for XDIR. See configuration.h for details
+XDIR_PIN | Pin to use for XDIR. See configuration.h for details
 
 And of course F_CPU should always be defined to the AVR's clock speed (in Hz).
 This code has only been tested with the AVR running at 24 MHz.

--- a/ccl.c
+++ b/ccl.c
@@ -10,24 +10,51 @@
 #include <stdlib.h>
 #include <avr/io.h>
 #include "ccl.h"
+#include "configuration.h"
 #include "hal_ln.h"
 
 
 void ccl_init(void)
 {
     // Event channels setup
-    // Ch0 UART 0 XDIR (PA4)
-    EVSYS.CHANNEL0 = EVSYS_CHANNEL0_PORTA_PIN4_gc;
+
+#if (XDIR_PORT_ID == 'A') || (XDIR_PORT_ID == 'B')
+
+    // Ch0 UART 0 XDIR
+#if XDIR_PORT_ID == 'A'
+    EVSYS.CHANNEL0 = EVSYS_CHANNEL0_PORTA_PIN0_gc + XDIR_PIN;
+#else
+    EVSYS.CHANNEL0 = EVSYS_CHANNEL0_PORTB_PIN0_gc + XDIR_PIN;
+#endif
     EVSYS.USERCCLLUT0A = 1;     // Channel 0
     EVSYS.USERCCLLUT3A = 1;     // Channel 0
-
-    // Ch1 AC1 out to TCB2 event in
-    EVSYS.CHANNEL1 = EVSYS_CHANNEL1_AC1_OUT_gc;
-    EVSYS.USERTCB2CAPT = 2;     // Channel 1
 
     // Ch2 LUT0 out to TCB0 event in
     EVSYS.CHANNEL2 = EVSYS_CHANNEL2_CCL_LUT0_gc;
     EVSYS.USERTCB0CAPT = 3;     // Channel 2
+
+#elif (XDIR_PORT_ID == 'C') || (XDIR_PORT_ID == 'D')
+
+    // Ch2 UART 0 XDIR
+#if XDIR_PORT_ID == 'C'
+    EVSYS.CHANNEL2 = EVSYS_CHANNEL2_PORTC_PIN0_gc + XDIR_PIN;
+#else
+    EVSYS.CHANNEL2 = EVSYS_CHANNEL2_PORTD_PIN0_gc + XDIR_PIN;
+#endif
+    EVSYS.USERCCLLUT0A = 3;     // Channel 2
+    EVSYS.USERCCLLUT3A = 3;     // Channel 2
+
+    // Ch0 LUT0 out to TCB0 event in
+    EVSYS.CHANNEL0 = EVSYS_CHANNEL0_CCL_LUT0_gc;
+    EVSYS.USERTCB0CAPT = 1;     // Channel 0
+
+#else
+#error "Invalid XDIR_PORT_ID configuration"
+#endif
+
+    // Ch1 AC1 out to TCB2 event in
+    EVSYS.CHANNEL1 = EVSYS_CHANNEL1_AC1_OUT_gc;
+    EVSYS.USERTCB2CAPT = 2;     // Channel 1
 
     // Ch3 TCB0 CAPT to LUT2 EventA
     EVSYS.CHANNEL3 = EVSYS_CHANNEL3_TCB0_CAPT_gc;

--- a/configuration.h
+++ b/configuration.h
@@ -1,0 +1,51 @@
+/*
+ * configuration.h
+ *
+ * Configuration macros for settings that are used
+ * throughout multiple source files.
+ *
+ * Created: 15-03-2026 14:36:53
+ *  Author: Mikael Ejberg Pedersen
+ */
+
+#ifndef CONFIGURATION_H_
+#define CONFIGURATION_H_
+
+/**
+ * Configuration for XDIR pin.
+ *
+ * The XDIR pin indicates if we are actively sending data on the LocoNet interface.
+ * It is used by the CCL to activate the collision detection logic.
+ * Note: The USARTs have a XDIR pin, but that is NOT used here. The XDIR pin from
+ * the USARTs generate too much delay for us to be able to take the bus within 2 µs.
+ * Instead, a GPIO pin is manually set when starting a transmission.
+ *
+ * The XDIR pin need to be configurable, as it may block other functionality,
+ * like TWI (I2C) or SPI.
+ *
+ * The default configuration is PORTC pin 2.
+ * Available pins on all AVR DA variants are:
+ *   PORTA pin 2-6,
+ *   PORTC pin 2,
+ *   PORTD pin 0-1 and 4-7.
+ * On 48 and 64 pin AVR's, PORTB pin 0-5 and PORTC pin 4-7 are also available.
+ * PORTs E, F and G could in theory also be used, but will require changes
+ * in the event routing channels.
+ *
+ * The following pins are NOT available for XDIR:
+ * PORTA pin 0-1 are used by USART0, and pin 7 is used by AC1 out.
+ * PORTB pin 6-7 can't connect the the event system, according to the AVR DA errata.
+ * PORTC pin 0-1 are used by USART1, and pin 3 is used by CCL-LUT1 out.
+ * PORTD pin 2 is used by AC1-AINP0, and pin 3 is used by CCL-LUT2/SEQ1 out (collision LED).
+ *
+ * Define XDIR_PORT to either PORTA, PORTB, PORTC or PORTD.
+ * Define XDIR_PORT_ID to a single char identifing the port selected ('A', 'B', 'C' or 'D').
+ * Define XDIR_PIN to a number between 0 and 7.
+ */
+#ifndef XDIR_PORT
+#define XDIR_PORT       PORTC
+#define XDIR_PORT_ID    'C'
+#define XDIR_PIN        2
+#endif
+
+#endif /* CONFIGURATION_H_ */

--- a/hal_ln.c
+++ b/hal_ln.c
@@ -22,6 +22,7 @@
 #include <util/delay.h>
 #include "ac.h"
 #include "ccl.h"
+#include "configuration.h"
 #include "fifo.h"
 #include "hal_ln.h"
 #include "ln_def.h"
@@ -171,7 +172,7 @@ static void tx_start(void)
         if (TCB2.STATUS & TCB_RUN_bm)
         {
             ccl_collision_clear();
-            PORTA.OUTSET = PIN4_bm;     // XDIR = 1
+            XDIR_PORT.OUTSET = 1 << XDIR_PIN;   // XDIR = 1
             USART0.TXDATAL = tx_buf->lndata.raw[0];
             tx_idx = 1;
             USART0.CTRLA |= USART_DREIE_bm;     // Enable data register empty interrupt
@@ -225,7 +226,7 @@ ISR(USART0_DRE_vect)
  */
 __attribute__((flatten)) ISR(USART0_TXC_vect)
 {
-    PORTA.OUTCLR = PIN4_bm;     // XDIR = 0
+    XDIR_PORT.OUTCLR = 1 << XDIR_PIN;   // XDIR = 0
     USART0.CTRLA &= ~USART_TXCIE_bm;
 
     if (ccl_collision())
@@ -407,7 +408,7 @@ __attribute__((flatten)) ISR(USART0_RXC_vect)
     }
 
 #ifndef LNECHO
-    if (PORTA.IN & PIN4_bm)     // XDIR
+    if (XDIR_PORT.IN & (1 << XDIR_PIN)) // XDIR
     {
         state = RXS_IDLE;       // Discard received echo of our own tx
         return;
@@ -523,8 +524,8 @@ void hal_ln_init(void)
 
     // Init USART pins
     PORTA.DIRCLR = PIN1_bm;     // RX input
-    PORTA.OUTCLR = PIN4_bm;
-    PORTA.DIRSET = PIN4_bm;     // TX active (manual XDIR pin with less delay)
+    XDIR_PORT.OUTCLR = 1 << XDIR_PIN;
+    XDIR_PORT.DIRSET = 1 << XDIR_PIN;   // TX active (manual XDIR pin with less delay)
 
     // Init USART
     USART0.CTRLA = USART_RXCIE_bm | USART_RS485_DISABLE_gc;     // Enable rx complete interrupt


### PR DESCRIPTION
The XDIR GPIO pin can now be placed on available pins on PORTs A, B, C and D.
Requires defining XDIR_PORT, XDIR_PORT_ID and XDIR_PIN. See configuration.h for further information.